### PR TITLE
refs

### DIFF
--- a/papers/kyle_sunden/.gitignore
+++ b/papers/kyle_sunden/.gitignore
@@ -1,0 +1,2 @@
+# emacs
+auto/*

--- a/papers/kyle_sunden/bib.bib
+++ b/papers/kyle_sunden/bib.bib
@@ -1,73 +1,86 @@
-@article{Kohler_2017,
-        doi = {10.1063/1.4986069},
-        url = {https://doi.org/10.1063%2F1.4986069},
-        year = 2017,
-        month = {aug},
-        publisher = {{AIP} Publishing},
-        volume = {147},
-        number = {8},
-        pages = {084202},
-        author = {Daniel D. Kohler and Blaise J. Thompson and John C. Wright},
-        title = {Frequency-domain coherent multidimensional spectroscopy when dephasing rivals pulsewidth},
-        journal = {The Journal of Chemical Physics}
-}
-
-@misc{snakeviz,
-
-    url = {http://jiffyclub.github.io/snakeviz/},
-    year = 2017,
-    author = {jiffyclub},
-    title = {SnakeViz}
-}
-
-@misc{nise,
-
-url = {http://github.com/wright-group/NISE},
-year = 2016,
-author = {Wright Group},
-title = {NISE: Numerical Integration of the Shr{\"o}dinger Equation}
-}
-
-@article{Nickolls_2008,
-        doi = {10.1145/1365490.1365500},
-        url = {https://doi.org/10.1145%2F1365490.1365500},
-        year = 2008,
-        month = {mar},
-        publisher = {Association for Computing Machinery ({ACM})},
-        volume = {6},
-        number = {2},
-        pages = {40},
-        author = {John Nickolls and Ian Buck and Michael Garland and Kevin Skadron},
-        title = {Scalable parallel programming with {CUDA}},
-        journal = {Queue}
+@article{Gelin_2009,
+  author =       {Gelin, Maxim F. and Egorova, Dassia and Domcke, Wolfgang},
+  title =        {Efficient Calculation of Time- and Frequency-Resolved Four-Wave-Mixing Signals},
+  journal =      {Accounts of Chemical Research},
+  volume =       42,
+  number =       9,
+  pages =        {1290--1298},
+  year =         2009,
+  doi =          {10.1021/ar900045d},
+  url =          {http://dx.doi.org/10.1021/ar900045d},
+  month =        {sep},
+  publisher =    {American Chemical Society ({ACS})},
 }
 
 @article{Klockner_2012,
- author = {Klöckner, Andreas and Pinto, Nicolas and Lee, Yunsup and Catanzaro, Bryan and Ivanov, Paul and Fasih, Ahmed},
- title = {{PyCUDA} and {PyOpenCL}: A scripting-based approach to {GPU} run-time code generation},
- journal = {Parallel Computing},
- publisher = {Elsevier {BV}},
- year = {2012},
- month = {mar},
- number = {3},
- volume = {38},
- pages = {157--174},
- url = {http://dx.doi.org/10.1016/j.parco.2011.09.001},
- doi = {10.1016/j.parco.2011.09.001}
+  author =       {Klöckner, Andreas and Pinto, Nicolas and Lee, Yunsup and Catanzaro, Bryan and
+                  Ivanov, Paul and Fasih, Ahmed},
+  title =        {{PyCUDA} and {PyOpenCL}: A scripting-based approach to {GPU} run-time code
+                  generation},
+  journal =      {Parallel Computing},
+  volume =       38,
+  number =       3,
+  pages =        {157--174},
+  year =         2012,
+  doi =          {10.1016/j.parco.2011.09.001},
+  url =          {http://dx.doi.org/10.1016/j.parco.2011.09.001},
+  month =        {mar},
+  publisher =    {Elsevier {BV}},
 }
 
-@article{Gelin_2009,
- author = {Gelin, Maxim F. and Egorova, Dassia and Domcke, Wolfgang},
- title = {Efficient Calculation of Time- and Frequency-Resolved Four-Wave-Mixing Signals},
- journal = {Accounts of Chemical Research},
- publisher = {American Chemical Society ({ACS})},
- year = {2009},
- month = {sep},
- number = {9},
- volume = {42},
- pages = {1290--1298},
- url = {http://dx.doi.org/10.1021/ar900045d},
- doi = {10.1021/ar900045d}
+@article{Kohler_2017,
+  author =       {Daniel D. Kohler and Blaise J. Thompson and John C. Wright},
+  title =        {Frequency-domain coherent multidimensional spectroscopy when dephasing rivals
+                  pulsewidth},
+  journal =      {The Journal of Chemical Physics},
+  volume =       147,
+  number =       8,
+  pages =        084202,
+  year =         2017,
+  doi =          {10.1063/1.4986069},
+  url =          {https://doi.org/10.1063%2F1.4986069},
+  month =        {aug},
+  publisher =    {{AIP} Publishing},
 }
 
+@incollection{Lee_1985,
+  address =      {London; New York},
+  author =       {Lee, Duckhwan and Albrecht, Andreas C.},
+  booktitle =    {Advances in infrared and Raman Spectroscopy},
+  chapter =      {4},
+  edition =      {1},
+  editor =       {Clark, R. J. H. and Hester, R. E.},
+  isbn =         {9780471906742},
+  pages =        {179--213},
+  title =        {A Unified View of Raman, Resonance Raman, and Fluorescence Spectroscopy (and
+                  their Analogues in Two-Photon Absorption},
+  year =         {1985},
+}
 
+@article{Nickolls_2008,
+  author =       {John Nickolls and Ian Buck and Michael Garland and Kevin Skadron},
+  title =        {Scalable parallel programming with {CUDA}},
+  journal =      {Queue},
+  volume =       6,
+  number =       2,
+  pages =        40,
+  year =         2008,
+  doi =          {10.1145/1365490.1365500},
+  url =          {https://doi.org/10.1145%2F1365490.1365500},
+  month =        {mar},
+  publisher =    {Association for Computing Machinery ({ACM})},
+}
+
+@misc{nise,
+  author =       {Wright Group},
+  title =        {NISE: Numerical Integration of the Shr{\"o}dinger Equation},
+  url =          {http://github.com/wright-group/NISE},
+  year =         2016,
+}
+
+@misc{snakeviz,
+  author =       {jiffyclub},
+  title =        {SnakeViz},
+  url =          {http://jiffyclub.github.io/snakeviz/},
+  year =         2017,
+}

--- a/papers/kyle_sunden/bib.bib
+++ b/papers/kyle_sunden/bib.bib
@@ -71,6 +71,21 @@
   publisher =    {Association for Computing Machinery ({ACM})},
 }
 
+@article{Petti_2018,
+  author =       {Megan K. Petti and Justin P. Lomont and Micha{\l} Maj and Martin T. Zanni},
+  title =        {Two-Dimensional Spectroscopy Is Being Used to Address Core Scientific Questions
+                  in Biology and Materials Science},
+  journal =      {The Journal of Physical Chemistry B},
+  volume =       122,
+  number =       6,
+  pages =        {1771--1780},
+  year =         2018,
+  doi =          {10.1021/acs.jpcb.7b11370},
+  url =          {https://doi.org/10.1021/acs.jpcb.7b11370},
+  month =        {feb},
+  publisher =    {American Chemical Society ({ACS})},
+}
+
 @misc{nise,
   author =       {Wright Group},
   title =        {NISE: Numerical Integration of the Shr{\"o}dinger Equation},

--- a/papers/kyle_sunden/bib.bib
+++ b/papers/kyle_sunden/bib.bib
@@ -1,3 +1,19 @@
+@article{Fournier_2009,
+  author =       {Frederic Fournier and Rui Guo and Elizabeth M. Gardner and Paul M. Donaldson and
+                  Christian Loeffeld and Ian R. Gould and Keith R. Willison and David R. Klug},
+  title =        {Biological and Biomedical Applications of Two-Dimensional Vibrational
+                  Spectroscopy: Proteomics, Imaging, and Structural Analysis},
+  journal =      {Accounts of Chemical Research},
+  volume =       42,
+  number =       9,
+  pages =        {1322--1331},
+  year =         2009,
+  doi =          {10.1021/ar900074p},
+  url =          {https://doi.org/10.1021/ar900074p},
+  month =        {sep},
+  publisher =    {American Chemical Society ({ACS})},
+}
+
 @article{Gelin_2009,
   author =       {Gelin, Maxim F. and Egorova, Dassia and Domcke, Wolfgang},
   title =        {Efficient Calculation of Time- and Frequency-Resolved Four-Wave-Mixing Signals},

--- a/papers/kyle_sunden/bib.bib
+++ b/papers/kyle_sunden/bib.bib
@@ -1,3 +1,17 @@
+@article{Czech_2015,
+  author =       {Kyle J. Czech and Blaise J. Thompson and Schuyler Kain and Qi Ding and Melinda J.
+                  Shearer and Robert J. Hamers and Song Jin and John C. Wright},
+  title =        {Measurement of Ultrafast Excitonic Dynamics of Few-Layer {MoS}2Using
+                  State-Selective Coherent Multidimensional Spectroscopy},
+  journal =      {{ACS} Nano},
+  volume =       9,
+  number =       12,
+  pages =        {12146--12157},
+  year =         2015,
+  doi =          {10.1021/acsnano.5b05198},
+  month =        {dec},
+}
+
 @article{Fournier_2009,
   author =       {Frederic Fournier and Rui Guo and Elizabeth M. Gardner and Paul M. Donaldson and
                   Christian Loeffeld and Ian R. Gould and Keith R. Willison and David R. Klug},

--- a/papers/kyle_sunden/bib.bib
+++ b/papers/kyle_sunden/bib.bib
@@ -101,6 +101,21 @@
   publisher =    {Association for Computing Machinery ({ACM})},
 }
 
+@article{Pakoulev_2009,
+  author =       {Andrei V. Pakoulev and Mark A. Rickard and Kathryn M. Kornau and Nathan A. Mathew
+                  and Lena A. Yurs and Stephen B. Block and John C. Wright},
+  title =        {Mixed Frequency-/Time-Domain Coherent Multidimensional Spectroscopy: Research
+                  Tool or Potential Analytical Method?},
+  journal =      {Accounts of Chemical Research},
+  volume =       42,
+  number =       9,
+  pages =        {1310--1321},
+  year =         2009,
+  doi =          {10.1021/ar900032g},
+  month =        {sep},
+  publisher =    {American Chemical Society ({ACS})},
+}
+
 @article{Petti_2018,
   author =       {Megan K. Petti and Justin P. Lomont and Micha{\l} Maj and Martin T. Zanni},
   title =        {Two-Dimensional Spectroscopy Is Being Used to Address Core Scientific Questions

--- a/papers/kyle_sunden/wrightsim.rst
+++ b/papers/kyle_sunden/wrightsim.rst
@@ -58,8 +58,8 @@ MDS can directly observe fundemental physics that are not possible to record in
 any other way.
 With recent advancements in lasers and optics, MDS experiments are becoming
 routine.
-Applications of MDS in semiconductor physics, drug screening, and other
-domains :cite:`Petti_2018` are currently being developed.
+Applications of MDS in semiconductor physics, medicine :cite:`Fournier_2009`,
+and other domains :cite:`Petti_2018` are currently being developed.
 Ultimately, MDS may become a key research tool akin to multidimensional
 nuclear magnetic resonance spectroscopy.
 

--- a/papers/kyle_sunden/wrightsim.rst
+++ b/papers/kyle_sunden/wrightsim.rst
@@ -62,7 +62,7 @@ Applications of MDS in semiconductor photophysics :cite:`Czech_2015`, medicine
 :cite:`Fournier_2009`, and other domains :cite:`Petti_2018` are currently being
 developed.
 Ultimately, MDS may become a key research tool akin to multidimensional
-nuclear magnetic resonance spectroscopy.
+nuclear magnetic resonance spectroscopy. :cite:`Pakoulev_2009`
 
 A generic MDS experiment involves exiting a sample with multiple pulses of
 light and measuring the magnitude of the sample response (the signal).

--- a/papers/kyle_sunden/wrightsim.rst
+++ b/papers/kyle_sunden/wrightsim.rst
@@ -59,7 +59,7 @@ any other way.
 With recent advancements in lasers and optics, MDS experiments are becoming
 routine.
 Applications of MDS in semiconductor physics, drug screening, and other
-domains are currently being developed.
+domains :cite:`Petti_2018` are currently being developed.
 Ultimately, MDS may become a key research tool akin to multidimensional
 nuclear magnetic resonance spectroscopy.
 

--- a/papers/kyle_sunden/wrightsim.rst
+++ b/papers/kyle_sunden/wrightsim.rst
@@ -37,7 +37,7 @@
     We report several algorithimic improvements that make ``WrightSim`` faster
     than previous implementations.
     The effect of parallelizing the simulation, both at the CPU and GPU
-    (CUDA) levels, is demonstrated. 
+    (CUDA) levels, is demonstrated.
     Taken together, algorithmic improvements and parallization has made
     ``WrightSim`` multiple orders of magnitude faster than previous
     implementations.
@@ -96,7 +96,7 @@ become an axis in the simulation.
 
 ``WrightSim`` is designed with the experimentalist in mind, allowing users
 to parameterize their simulations in much the same way that they would collect
-a similar spectrum in the laboratory. 
+a similar spectrum in the laboratory.
 ``WrightSim`` is modular and flexible---it is capable of simulating different
 kinds of MDS, and it is easy to extend to new kinds.
 ``WrightSim`` uses a numerical integration approach that captures the full
@@ -107,11 +107,11 @@ This approach makes ``WrightSim`` flexible, accurate, and interpretable.
 While the numerical approach we use is more accurate, it does demand
 significantly more computational time.
 We have focused on performance as a critical component of ``WrightSim``.
-Here we report algorithmic improvements which have significantly decreased 
+Here we report algorithmic improvements which have significantly decreased
 computational time relative to prior implementations.
 We also discuss parallelzation approaches we have taken, and show how the
 symmetry of the simulation can be exploited.
-``WrightSim`` is still at a nascent stage of development, but has already 
+``WrightSim`` is still at a nascent stage of development, but has already
 shown itself to be a powerful tool.
 
 
@@ -129,32 +129,34 @@ We propagate all of the relevant density matrix elements, including
 populations and coherences, in our numerical simulation.
 This strategy has been described before :cite:`Gelin_2009`, so we are brief in our
 description here.
-This places ``WrightSim`` at an intermediate level of theory, one where 
-the mechanisms by which the desired signal arises are known, but have 
+This places ``WrightSim`` at an intermediate level of theory, one where
+the mechanisms by which the desired signal arises are known, but have
 non-trivial spectral features as a result.
-This package does **not** perform *ab initio* computations, nor is it simply 
+This package does **not** perform *ab initio* computations, nor is it simply
 plotting a collection of well-behaved peaked functions with amplitudes and widths
 from experimental spectra.
 
 Here, we are simulating the interactions of three electric fields to
-induce an output electric field. These fields can interact in a
-combinatorially large number of fashions. For three fields, there are
-six possible time orderings for the pulses to interact and create
-superpositions or populations in the material system. We are restricting
-this simulation to have two positive interactions (solid up arrows or
-dashed down arrows) and one negative interaction (dashed up arrow or
-solid down arrow). 
+induce an output electric field.
+These fields can interact with our sample via several different pathways.
+Figure :ref:`fig:WMELs` shows a series of wave mixing energy level (WMEL)
+diagrams :cite:`Lee_1985` representing each of these 16 pathways.
+For three fields, there are six possible time orderings for the pulses to
+interact and create superpositions or populations in the material system
+(columns in Figure :ref:`fig:WMELs`).
+We are restricting this simulation to have two positive interactions (solid up
+arrows or dashed down arrows) and one negative interaction (dashed up arrow or
+solid down arrow).
 Experimentalists isolate this condition spatially, by placing an aperature
 where this condition is met.
-This results in 16 independently resolvable possible
-pathways which result in a productive emission. Figure :ref:`fig:WMELs` shows
-these 16 pathways, arranged by their time ordering (I - VI). For the
-purposes of this paper it is not necessary to fully understand what is
-meant by this diagram, the intent is simply to show the complexity of
-the problem at hand. Experimentalists can isolate the time orderings by
-introducing delays between pulses to preferentially follow the according
-pathways. Simulation allows us to fully separate these time orderings
-and pathways, to as fine a detail as desired.
+This results in 16 possible pathways which result in a productive emission.
+For the purposes of this paper it is not necessary to fully understand what is
+meant by this diagram, the intent is simply to show the complexity of the
+problem at hand.
+Experimentalists can isolate the time orderings by introducing delays between
+pulses.
+Simulation allows us to fully separate each pathway, leading to insight into
+the nature of pathway interference in the total signal lineshape.
 
 .. figure:: WMELs.png
 
@@ -172,10 +174,10 @@ and pathways, to as fine a detail as desired.
     with (the superscript). Arrows indicate interactions with
     :math:`\omega_1` (blue), :math:`\omega_{2^\prime}` (red), and
     :math:`\omega_2` (green). Figure was originally published as Figure S1
-    of Kohler, Thompson, and Wright :cite:`Kohler_2017` :label:`fig:fsa` 
+    of Kohler, Thompson, and Wright :cite:`Kohler_2017` :label:`fig:fsa`
 
 Figure :ref:`fig:fsa` shows a finite state automata, starting at
-the ground state (:math:`\rho_{00}`). The nodes are the density matrix 
+the ground state (:math:`\rho_{00}`). The nodes are the density matrix
 elements themselves. Encoded within each node is both
 the quantum mechanical state and the fields with which the system has
 already interacted. Interactions occur along the arrows, which generate
@@ -281,9 +283,9 @@ simulations of this kind.
 Usage
 =====
 
-``WrightSim`` is designed in a modular, extensible manner in order to be 
+``WrightSim`` is designed in a modular, extensible manner in order to be
 friendly to experimentalists and theorists alike.
-The key steps to running a basic simulation are: 
+The key steps to running a basic simulation are:
 
 - Define the experimental space
 - Select a hamiltonian for propagation
@@ -298,7 +300,7 @@ three incident pulses.
 The frequency axes are called ``w1`` and ``w2`` [#]_, the delays are termed ``d1`` and ``d2``.
 To scan a particular axis, simply set the ``points`` array to a ``NumPy`` array and set it's ``active``
 attribute to ``True``.
-You can also set a static value for any available axis, by setting the ``points`` attribute to 
+You can also set a static value for any available axis, by setting the ``points`` attribute to
 a single number (and keeping ``active`` set to ``False``).
 Finally, the ``experiment`` class tracks the timing in the simulation.
 Three main parameters control this: ``timestep``, which controls the size of each numerical integration step,
@@ -348,7 +350,7 @@ in the end result array.
 Hamiltonians may have arbitrary parameters to define themselves in intuitive ways.
 Under the hood, the Hamiltonian class also holds the C struct and source code for the ``PyCUDA``
 implementation and a method to send itself to the CUDA device.
-Here is an example of setting up a Hamiltonian object with restricted pathways and explicitly set 
+Here is an example of setting up a Hamiltonian object with restricted pathways and explicitly set
 recorded element parameters:
 
 .. code-block:: python
@@ -373,18 +375,18 @@ The exception is the special string ``'gpu'``, which will cause ``WrightSim`` to
 
     # do scan, using PyCUDA
     scan = exp.run(ham, mp='gpu')
-    
+
     # obtain results as a NumPy array
     gpuSig = scan.sig.copy()
 
-Running returns a ``Scan`` object, which allows for interrogation of several internal features of the scan 
+Running returns a ``Scan`` object, which allows for interrogation of several internal features of the scan
 including the electric field values themselves.
 The important part, however is the signal array that is generated.
-In this example, the complex floating point number array is of shape :math:`(2x64x64x32)` (i.e. the number of 
+In this example, the complex floating point number array is of shape :math:`(2x64x64x32)` (i.e. the number of
 ``recorded_elements`` followed by the shape of the experiment itself).
 These numbers can be manipulated and visualized to produce spectra like that seen in :ref:`fig:examplespectrum`.
-The Wright Group also maintains a library for working with multidimensional data, ``WrightTools``. 
-This library will be integrated more fully to provide even easier access to visualization and 
+The Wright Group also maintains a library for working with multidimensional data, ``WrightTools``.
+This library will be integrated more fully to provide even easier access to visualization and
 archival storage of simulation results.
 
 
@@ -582,7 +584,7 @@ responses using an HDF5 based file format. The CUDA implementation
 itself would benefit from some way of saving the compiled code for
 multiple runs, removing the 0.2 second overhead. Current implementation
 compiles directly before calling the kernel, whether it has compiled it
-before or not. If performing many simulations in quick succession (e.g. 
+before or not. If performing many simulations in quick succession (e.g.
 a simulation larger than the memory allows in a single kernel call) with
 the same C code, the savings would add up.
 

--- a/papers/kyle_sunden/wrightsim.rst
+++ b/papers/kyle_sunden/wrightsim.rst
@@ -58,8 +58,9 @@ MDS can directly observe fundemental physics that are not possible to record in
 any other way.
 With recent advancements in lasers and optics, MDS experiments are becoming
 routine.
-Applications of MDS in semiconductor physics, medicine :cite:`Fournier_2009`,
-and other domains :cite:`Petti_2018` are currently being developed.
+Applications of MDS in semiconductor photophysics :cite:`Czech_2015`, medicine
+:cite:`Fournier_2009`, and other domains :cite:`Petti_2018` are currently being
+developed.
 Ultimately, MDS may become a key research tool akin to multidimensional
 nuclear magnetic resonance spectroscopy.
 


### PR DESCRIPTION
added some references, updated the text to reflect them

my editor automatically removes trailing spaces---sorry to spam the diff :blush: 

(edit) I just discovered that GitHub has a "ignore white space changes" checkbox in the Files changed tab which is helpful in this case